### PR TITLE
4.0.1 - woo-better-shipping-calculator-for-brazil (Correções e melhorias no readme.txt do plugin)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
       uses: mathieudutour/github-tag-action@v6.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        custom_tag: '4.0.0' # // TODO caso necessário definir a tag da release manualmente
+        custom_tag: '4.0.1' # // TODO caso necessário definir a tag da release manualmente
 
     # Generate new release
     - name: Generate new Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 4.0.1 - 23/04/25
+* Correção: Novo Readme.txt e lista de imagens.
+
 # 4.0.0 - 26/03/25
 * Ajuste: Alteração do plugin para o modelo de Orientação a Objetos (OO).
 * Novo tab de configuração para o plugin.

--- a/Includes/WcBetterShippingCalculatorForBrazil.php
+++ b/Includes/WcBetterShippingCalculatorForBrazil.php
@@ -77,7 +77,7 @@ class WcBetterShippingCalculatorForBrazil
         if (defined('WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_VERSION')) {
             $this->version = WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_VERSION;
         } else {
-            $this->version = '4.0.0';
+            $this->version = '4.0.1';
         }
         $this->plugin_name = 'wc-better-shipping-calculator-for-brazil';
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 * Tags: woocommerce, brasil, calculadora de frete, CEP
 * Testado até: 6.8
 * Requer PHP: 7.3
-* Tag estável: 4.0.0
+* Tag estável: 4.0.1
 * Licença: GPLv2 ou posterior
 * URI da licença: [https://www.gnu.org/licenses/gpl-2.0.html](https://www.gnu.org/licenses/gpl-2.0.html)
 
@@ -33,7 +33,6 @@ Calculadora de frete melhorada para lojas brasileiras:
 * Habilita campo de número de endereço.
 * Habilita verificador de cep.
 * Desabilita frete no produto.
-
 
 ## Como instalar?
 

--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: woocommerce, brazil, shipping calculator, postcode
 Requires at least: 4.6  
 Tested up to: 6.8
 Requires PHP: 7.3  
-Stable tag: 4.0.0
+Stable tag: 4.0.1
 License: GPLv2 or later  
 License URI: [https://www.gnu.org/licenses/gpl-2.0.html](https://www.gnu.org/licenses/gpl-2.0.html)  
 
@@ -13,60 +13,65 @@ WooCommerce shipping calculator without Country and State fields. Keeping only t
 
 == Description ==  
 
-WooCommerce shipping calculator optimized for Brazilian stores:  
+Calculadora de frete WooCommerce otimizada para lojas brasileiras:
 
-* Removes country, state, and city fields.  
-* Keeps the postcode field always visible.  
-* Allows only numbers to be entered in the postcode field.  
-* Displays a numeric keyboard on mobile devices.  
-* Enables address number field.
-* Enables ZIP code validator.
-* Disables shipping on the product.
+* Remove os campos de país, estado e cidade.
+* Mantém o campo de CEP sempre visível.
+* Permite apenas números no campo de CEP.
+* Exibe um teclado numérico em dispositivos móveis.
+* Habilita o campo de número do endereço.
+* Habilita o validador de CEP.
+* Desabilita o frete no produto.
 
-Some of these features can be modified or disabled using hooks. More details in the [Frequently Asked Questions (FAQ)](#faq) section.  
+Algumas dessas funcionalidades podem ser modificadas ou desativadas usando hooks. Mais detalhes na seção [Perguntas Frequentes (FAQ)](#faq).
 
 = Help and Support =  
 
-When you need help, create a topic in the [Plugin Forum](https://wordpress.org/support/plugin/woo-better-shipping-calculator-for-brazil/).  
+Quando precisar de ajuda, crie um tópico no [Fórum de Suporte do Plugin](https://wordpress.org/support/plugin/woo-better-shipping-calculator-for-brazil/).
 
 = Contributions =  
 
-If you find any bugs or have suggestions, open an issue in our [GitHub repository](https://github.com/luizbills/wc-better-shipping-calculator-for-brazil).
+Se encontrar algum erro ou tiver sugestões, abra um problema no nosso [repositório no GitHub](https://github.com/luizbills/wc-better-shipping-calculator-for-brazil).
 
-[Brasil API](https://brasilapi.com.br) - CEP Field.
+[Brasil API](https://brasilapi.com.br) - Campo de CEP.
 
 == Installation ==  
 
-1. Access your WordPress admin and go to **Plugins > Add New**.  
-2. Search for "Improved Shipping Calculator for Brazilian Stores".
-3. Find the plugin, click "Install Now", and then "Activate".
-4. Done! No further configuration needed.
+1. Acesse o admin do seu WordPress e vá para **Plugins > Adicionar Novo**.
+2. Busque por "Calculadora de Frete Melhorada para Lojas Brasileiras".
+3. Encontre o plugin, clique em "Instalar Agora" e depois em "Ativar".
+4. Pronto! Nenhuma configuração adicional necessária.
 
 == Screenshots ==  
 
-1. Comparison before and after installing the plugin.  
-2. Final result.
+1. Nova página de configuração do plugin.
+2. Tela antiga do carrinho através do editor de blocos do Gutenberg.
+3. Tela nova do carrinho através do editor de blocos do Gutenberg.
+4. Tela antiga do carrinho através do shortcode do WooCommerce.
+4. Tela nova do carrinho através do shortcode do WooCommerce.
+6. Campo de número através do editor de blocos do Gutenberg.
+7. Campo de número através do shortcode do WooCommerce.
 
 == Frequently Asked Questions ==  
 
-= How can I CHANGE the text "Calculate shipping"? =  
+= Como posso ALTERAR o texto "Calcular frete"? =
 
-Use the following code:  
+Use o seguinte código:
 
-```php
+```
 add_filter(
     'wc_better_shipping_calculator_for_brazil_postcode_label',
     function () {
-        return 'your new text';
+        return 'seu novo texto';
     }
 );
 ```
 
-= How can I REMOVE the text "Calculate shipping"? =
+= Como posso REMOVER o texto "Calcular frete"? =
 
-Use the following code:
+Use o seguinte código:
 
-```php
+```
 add_filter(
     'wc_better_shipping_calculator_for_brazil_postcode_label',
     '__return_null'
@@ -74,6 +79,9 @@ add_filter(
 ```
 
 == Changelog ==
+
+= 4.0.1 - 2025/04/23 =
+* Fix: New Readme.txt and image list.
 
 = 4.0.0 - 2025/03/26 =
 * Adjustment: Refactored the plugin to follow the Object-Oriented (OO) model.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-php-dev-container",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "This repository provides a development environment for WordPress",
   "repository": {
     "type": "git",

--- a/wc-better-shipping-calculator-for-brazil.php
+++ b/wc-better-shipping-calculator-for-brazil.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Calculadora de frete melhorada para lojas brasileiras
  * Plugin URI:        https://www.linknacional.com.br/wordpress
  * Description:       Calculadora de frete do WooCommerce otimizada para lojas brasileiras: remove dos campos de país, estado e cidade. E alguns outros ajustes.
- * Version:           4.0.0
+ * Version:           4.0.1
  * Author:            Link Nacional
  * Author URI:        https://linknacional.com.br/
  * Requires PHP:      7.3
@@ -46,7 +46,7 @@ if (! defined('WPINC')) {
  */
 // Consts
 if (! defined('WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_VERSION')) {
-    define('WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_VERSION', '4.0.0');
+    define('WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_VERSION', '4.0.1');
 }
 
 if (! defined('WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_MIN_GIVE_VERSION')) {


### PR DESCRIPTION
# Calculadora de frete melhorada para lojas brasileiras

* Contribuidores: LinkNacional
* Link para doações: [LinkNacional](https://www.linknacional.com.br/)
* Tags: woocommerce, brasil, calculadora de frete, CEP
* Testado até: 6.7
* Requer PHP: 7.3
* Tag estável: 4.0.1
* Licença: GPLv2 ou posterior
* URI da licença: [https://www.gnu.org/licenses/gpl-2.0.html](https://www.gnu.org/licenses/gpl-2.0.html)
* Traduções: Português(Brasil)

## Descrição

Calculadora de frete melhorada para lojas brasileiras:

* Remove os campos de país, estado e cidade.
* Mantém o campo de CEP sempre visível.
* Permite apenas a inserção de números no campo de CEP.
* Exibe um teclado numérico em dispositivos móveis.
* Habilita campo de número de endereço.
* Habilita verificador de cep.
* Desabilita frete no produto.

## Como instalar?

1. Acesse o painel de administração do WordPress e vá para **Plugins > Adicionar Novo**.
2. Pesquise por "Calculadora de frete melhorada para lojas brasileiras".
3. Encontre o plugin, clique em **Instalar Agora** e depois em **Ativar**.
4. Pronto! Nenhuma configuração adicional é necessária.

## Resumo(4.0.1):

> Nova descrição para o Readme.txt, junto com novas imagens de exibição do plugin.
![image](https://github.com/user-attachments/assets/c588e337-092a-4bce-be4d-ed06331cb530)

