### PR TITLE
4.1.2 - woo-better-shipping-calculator-for-brazil (Ajustes na identificação de produtos físicos e digitais)

### DIFF
--- a/Admin/WcBetterShippingCalculatorForBrazilAdmin.php
+++ b/Admin/WcBetterShippingCalculatorForBrazilAdmin.php
@@ -80,7 +80,6 @@ class WcBetterShippingCalculatorForBrazilAdmin
          * class.
          */
 
-        wp_enqueue_style($this->plugin_name, plugin_dir_url(__FILE__) . 'css/WcBetterShippingCalculatorForBrazilAdmin.css', array(), $this->version, 'all');
 
     }
 
@@ -103,10 +102,6 @@ class WcBetterShippingCalculatorForBrazilAdmin
          * between the defined hooks and the functions defined in this
          * class.
          */
-        wp_enqueue_script($this->plugin_name, plugin_dir_url(__FILE__) . 'js/WcBetterShippingCalculatorForBrazilAdmin.js', array( 'jquery' ), $this->version, false);
-
-        wp_enqueue_script($this->plugin_name . '-settings', plugin_dir_url(__FILE__) . 'js/WcBetterShippingCalculatorForBrazilAdmin.js', array( 'jquery' ), $this->version, false);
-
     }
 
     public function add_extra_css()

--- a/Public/WcBetterShippingCalculatorForBrazilPublic.php
+++ b/Public/WcBetterShippingCalculatorForBrazilPublic.php
@@ -79,8 +79,10 @@ class WcBetterShippingCalculatorForBrazilPublic
          * class.
          */
 
-        wp_enqueue_style($this->plugin_name, plugin_dir_url(__FILE__) . 'css/WcBetterShippingCalculatorForBrazilPublic.css', array(), $this->version, 'all');
-
+        $cep_required = get_option('woo_better_calc_cep_required', 'no');
+        if ($cep_required === 'yes') {
+            wp_enqueue_style($this->plugin_name, plugin_dir_url(__FILE__) . 'css/WcBetterShippingCalculatorForBrazilPublic.css', array(), $this->version, 'all');
+        }
     }
 
     /**
@@ -102,9 +104,6 @@ class WcBetterShippingCalculatorForBrazilPublic
          * between the defined hooks and the functions defined in this
          * class.
          */
-
-        wp_enqueue_script($this->plugin_name, plugin_dir_url(__FILE__) . 'js/WcBetterShippingCalculatorForBrazilPublic.js', array( 'jquery' ), $this->version, false);
-
         $disabled_shipping = get_option('woo_better_calc_disabled_shipping', 'default');
         $hidden_address = get_option('woo_better_hidden_cart_address', 'yes');
         $cep_required = get_option('woo_better_calc_cep_required', 'no');

--- a/Public/css/WcBetterShippingCalculatorForBrazilPublic.css
+++ b/Public/css/WcBetterShippingCalculatorForBrazilPublic.css
@@ -28,7 +28,3 @@
 .lkn-wc-shipping-address-summary {
     background-color: rgba(0, 0, 0, 0.205);
 }
-
-#4-country {
-    display: none !important;
-}


### PR DESCRIPTION
# Calculadora de frete melhorada para lojas brasileiras

* Contribuidores: LinkNacional
* Link para doações: [LinkNacional](https://www.linknacional.com.br/)
* Tags: woocommerce, brasil, calculadora de frete, CEP
* Testado até: 6.7
* Requer PHP: 7.3
* Tag estável: 4.1.2
* Licença: GPLv2 ou posterior
* URI da licença: [https://www.gnu.org/licenses/gpl-2.0.html](https://www.gnu.org/licenses/gpl-2.0.html)
* Traduções: Português(Brasil)

## Descrição

Calculadora de frete WooCommerce otimizada para lojas brasileiras:

* Remove os campos de país, estado e cidade.
* Mantém o campo de CEP sempre visível.
* Permite apenas números no campo de CEP.
* Exibe um teclado numérico em dispositivos móveis.
* Habilita o campo de número para complementar o endereço.
* Habilita o validador de CEP(Editor de blocos do Gutenberg).
* Desabilita o frete no produto.
* Compatibilidade com o editor de blocos do Gutenberg e shortcode(modo clássico).

Algumas dessas funcionalidades podem ser modificadas ou desativadas usando hooks. Mais detalhes na seção [Perguntas Frequentes (FAQ)](#faq).

## Como instalar?

1. Acesse o painel de administração do WordPress e vá para **Plugins > Adicionar Novo**.
2. Pesquise por "Calculadora de frete melhorada para lojas brasileiras".
3. Encontre o plugin, clique em **Instalar Agora** e depois em **Ativar**.
4. Pronto! Nenhuma configuração adicional é necessária.

## Resumo(4.1.2):

> Ajustes na identificação de produtos físicos e digitais.

![image](https://github.com/user-attachments/assets/ad90b3a8-75ba-4639-9dd9-119c60790e07)

* O campo de `CEP` era gerado independente da opção selecionada, mesmo que o produto fosse digital e não necessitasse de um CEP requerido. 

> Melhoria no action

* Agora o fluxo de lançamento do plugin será implementado em 2 etapas:

1 - Verificação do plugin(plugin check) -> Separação dos arquivos -> Zipa conteúdo -> Lança versão "beta" no repositório do plugin para controle de versão e teste.  

2 - Separação dos arquivos -> Lançamento na plataforma Wordpress.