### PR TITLE
4.1.3 - woo-better-shipping-calculator-for-brazil (Ajustes no blueprint do playground e valores padrão)

### DIFF
--- a/Public/WcBetterShippingCalculatorForBrazilPublic.php
+++ b/Public/WcBetterShippingCalculatorForBrazilPublic.php
@@ -79,9 +79,12 @@ class WcBetterShippingCalculatorForBrazilPublic
          * class.
          */
 
-        $cep_required = get_option('woo_better_calc_cep_required', 'yes');
-        if ($cep_required === 'yes') {
-            wp_enqueue_style($this->plugin_name, plugin_dir_url(__FILE__) . 'css/WcBetterShippingCalculatorForBrazilPublic.css', array(), $this->version, 'all');
+        if (has_block('woocommerce/cart')) {
+            $cep_required = get_option('woo_better_calc_cep_required', 'yes');
+
+            if ($cep_required === 'yes') {
+                wp_enqueue_style($this->plugin_name, plugin_dir_url(__FILE__) . 'css/WcBetterShippingCalculatorForBrazilPublic.css', array(), $this->version, 'all');
+            }
         }
     }
 


### PR DESCRIPTION
# Calculadora de frete melhorada para lojas brasileiras

* Contribuidores: LinkNacional
* Link para doações: [LinkNacional](https://www.linknacional.com.br/)
* Tags: woocommerce, brasil, calculadora de frete, CEP
* Testado até: 6.7
* Requer PHP: 7.3
* Tag estável: 4.1.3
* Licença: GPLv2 ou posterior
* URI da licença: [https://www.gnu.org/licenses/gpl-2.0.html](https://www.gnu.org/licenses/gpl-2.0.html)
* Traduções: Português(Brasil)

## Descrição

Calculadora de frete WooCommerce otimizada para lojas brasileiras:

> Na página de Carrinho:

- Validação de CEP.
- Controle no botão de envio, permitindo apenas seguir após inserir um CEP válido.
- Ocultação de campos de endereço.
- Compatibilidade com o modo Legacy e Blocos (Gutenberg).

> Na página de Checkout:

- Campo de número(complementando o endereço via `checkbox` ou `text-input`).
- Ocultação de campos de endereço.
- Compatibilidade com o modo Legacy e Blocos (Gutenberg).

Algumas dessas funcionalidades podem ser modificadas ou desativadas usando hooks. Mais detalhes na seção [Perguntas Frequentes (FAQ)](#faq).

## Como instalar?

1. Acesse o painel de administração do WordPress e vá para **Plugins > Adicionar Novo**.
2. Pesquise por "Calculadora de frete melhorada para lojas brasileiras".
3. Encontre o plugin, clique em **Instalar Agora** e depois em **Ativar**.
4. Pronto! Nenhuma configuração adicional é necessária.

## Resumo(4.1.3):

> Ajustes no blueprint(Playground), agora o fluxo se tornou mais dinâmico, permitindo que o usuário foque apenas em testar o plugin a partir da página de produto:

![image](https://github.com/user-attachments/assets/17fe8dff-2083-4324-8a7b-98504e286056)

> Alguns campos de configuração estavam desatualizados em seu valor padrão e foi corrigido na versão atual.