### PR TITLE
4.1.4 - woo-better-shipping-calculator-for-brazil (Remoção do campo bairro)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 env:
   PLUGIN_NAME: woo-better-shipping-calculator-for-brazil
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "4.1.3"
+  DEPLOY_TAG: "4.1.4"
 jobs:
   release-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/resumeLog.yml
+++ b/.github/workflows/resumeLog.yml
@@ -6,7 +6,7 @@ on:
 env:
   PLUGIN_NAME: woo-better-shipping-calculator-for-brazil
   TITLE: "Ajustes no blueprint do playground e valores padrão"
-  VERSION: "4.1.3"
+  VERSION: "4.1.4"
 
 jobs:
   send-email:

--- a/.github/workflows/wordpressRelease.yml
+++ b/.github/workflows/wordpressRelease.yml
@@ -6,7 +6,7 @@ on:
 env:
   PLUGIN_NAME: woo-better-shipping-calculator-for-brazil
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "4.1.3"
+  DEPLOY_TAG: "4.1.4"
 
 jobs:
   deploy-to-wp:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.1.4 - 20/05/25
+* Ajuste: campo de bairro está fora dos parâmetros estabelecidos.
+* Ajuste: tags do arquivo README.txt.
+
 # 4.1.3 - 15/05/25
 * Ajuste: blueprint mais dinâmico no momento da configuração do playground.
 

--- a/Includes/WcBetterShippingCalculatorForBrazil.php
+++ b/Includes/WcBetterShippingCalculatorForBrazil.php
@@ -79,7 +79,7 @@ class WcBetterShippingCalculatorForBrazil
         if (defined('WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_VERSION')) {
             $this->version = WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_VERSION;
         } else {
-            $this->version = '4.1.3';
+            $this->version = '4.1.4';
         }
         $this->plugin_name = 'wc-better-shipping-calculator-for-brazil';
 

--- a/Includes/WcBetterShippingCalculatorForBrazil.php
+++ b/Includes/WcBetterShippingCalculatorForBrazil.php
@@ -334,10 +334,6 @@ class WcBetterShippingCalculatorForBrazil
             }
         }
 
-        if (isset($fields['billing']['billing_neighborhood'])) {
-            unset($fields['billing']['billing_neighborhood']);
-        }
-
         if ($number_field === 'yes' && ($disabled_shipping === 'default' || !$only_virtual && $disabled_shipping === 'digital')) {
             // Adiciona um novo campo dentro do endereço de cobrança
             $fields['billing']['lkn_billing_number'] = array(

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 * Tags: woocommerce, brasil, calculadora de frete, CEP, entrega
 * Testado até: 6.8
 * Requer PHP: 7.3
-* Tag estável: 4.1.3
+* Tag estável: 4.1.4
 * Licença: GPLv2 ou posterior
 * URI da licença: [https://www.gnu.org/licenses/gpl-2.0.html](https://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 * Contribuidores: LinkNacional
 * Link para doações: [LinkNacional](https://www.linknacional.com.br/)
-* Tags: woocommerce, brasil, calculadora de frete, CEP
+* Tags: woocommerce, brasil, calculadora de frete, CEP, entrega
 * Testado até: 6.8
 * Requer PHP: 7.3
 * Tag estável: 4.1.3

--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: woocommerce, brasil, calculadora de frete, CEP, entrega
 Requires at least: 4.6
 Tested up to: 6.8
 Requires PHP: 7.3
-Stable tag: 4.1.3
+Stable tag: 4.1.4
 License: GPLv2 or later
 License URI: [https://www.gnu.org/licenses/gpl-2.0.html](https://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/README.txt
+++ b/README.txt
@@ -1,7 +1,7 @@
 === Calculadora de Frete para o Brasil ===
 Contributors: LinkNacional
 Donate link:
-Tags: woocommerce, brasil, calculadora de frete, CEP
+Tags: woocommerce, brasil, calculadora de frete, CEP, entrega
 Requires at least: 4.6
 Tested up to: 6.8
 Requires PHP: 7.3
@@ -81,6 +81,10 @@ add_filter(
 );
 
 == Changelog ==
+
+= 4.1.4 - 20/05/2025 =
+* Ajuste: campo de bairro está fora dos parâmetros estabelecidos.
+* Ajuste: tags do arquivo README.txt.
 
 = 4.1.3 - 15/05/2025 =
 * Ajuste: blueprint mais dinâmico no momento da configuração do playground.

--- a/RESUMELOG.md
+++ b/RESUMELOG.md
@@ -1,8 +1,12 @@
+# 4.1.4 - 20/05/25
+* Ajuste: campo de bairro está fora dos parâmetros estabelecidos.
+* Ajuste: tags do arquivo README.txt.
+
+# 4.1.3 - 15/05/25
+* Ajuste: blueprint mais dinâmico no momento da configuração do playground.
+
 > Ajustes no blueprint(Playground), agora o fluxo se tornou mais dinâmico, permitindo que o usuário foque apenas em testar o plugin a partir da página de produto:
 
 ![image](https://github.com/user-attachments/assets/17fe8dff-2083-4324-8a7b-98504e286056)
 
 > Alguns campos de configuração estavam desatualizados em seu valor padrão e foi corrigido na versão atual.
-
-# 4.1.3 - 15/05/25
-* Ajuste: blueprint mais dinâmico no momento da configuração do playground.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-php-dev-container",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "description": "This repository provides a development environment for WordPress",
   "repository": {
     "type": "git",

--- a/wc-better-shipping-calculator-for-brazil.php
+++ b/wc-better-shipping-calculator-for-brazil.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Calculadora de Frete para o Brasil
  * Plugin URI:        https://www.linknacional.com.br/wordpress
  * Description:       Calculadora automática de Frete com CEP para Woocommerce. Sem necessidade de informar o Pais e estado. Compatível com Gutenberg e shortcodes. Ideal para Lojas Brasileiras.
- * Version:           4.1.3
+ * Version:           4.1.4
  * Author:            Link Nacional
  * Author URI:        https://linknacional.com.br/
  * Requires PHP:      7.3
@@ -46,7 +46,7 @@ if (! defined('WPINC')) {
  */
 // Consts
 if (! defined('WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_VERSION')) {
-    define('WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_VERSION', '4.1.3');
+    define('WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_VERSION', '4.1.4');
 }
 
 if (! defined('WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_MIN_GIVE_VERSION')) {


### PR DESCRIPTION
# Calculadora de frete melhorada para lojas brasileiras

* Contribuidores: LinkNacional
* Link para doações: [LinkNacional](https://www.linknacional.com.br/)
* Tags: woocommerce, brasil, calculadora de frete, CEP
* Testado até: 6.7
* Requer PHP: 7.3
* Tag estável: 4.1.4
* Licença: GPLv2 ou posterior
* URI da licença: [https://www.gnu.org/licenses/gpl-2.0.html](https://www.gnu.org/licenses/gpl-2.0.html)
* Traduções: Português(Brasil)

## Descrição

Calculadora de frete WooCommerce otimizada para lojas brasileiras:

> Na página de Carrinho:

- Validação de CEP.
- Controle no botão de envio, permitindo apenas seguir após inserir um CEP válido.
- Ocultação de campos de endereço.
- Compatibilidade com o modo Legacy e Blocos (Gutenberg).

> Na página de Checkout:

- Campo de número(complementando o endereço via `checkbox` ou `text-input`).
- Ocultação de campos de endereço.
- Compatibilidade com o modo Legacy e Blocos (Gutenberg).

Algumas dessas funcionalidades podem ser modificadas ou desativadas usando hooks. Mais detalhes na seção [Perguntas Frequentes (FAQ)](#faq).

## Como instalar?

1. Acesse o painel de administração do WordPress e vá para **Plugins > Adicionar Novo**.
2. Pesquise por "Calculadora de frete melhorada para lojas brasileiras".
3. Encontre o plugin, clique em **Instalar Agora** e depois em **Ativar**.
4. Pronto! Nenhuma configuração adicional é necessária.

## Resumo(4.1.4):

> Remoção do campo bairro, no qual estava causando  incompatibilidade com o plugin: `Brazilian Market`