### PR TITLE
4.1.5 - woo-better-shipping-calculator-for-brazil (Remoção do campo bairro)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 env:
   PLUGIN_NAME: woo-better-shipping-calculator-for-brazil
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "4.1.4"
+  DEPLOY_TAG: "4.1.5"
 jobs:
   release-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/resumeLog.yml
+++ b/.github/workflows/resumeLog.yml
@@ -6,7 +6,7 @@ on:
 env:
   PLUGIN_NAME: woo-better-shipping-calculator-for-brazil
   TITLE: "Ajustes no blueprint do playground e valores padrão"
-  VERSION: "4.1.4"
+  VERSION: "4.1.5"
 
 jobs:
   send-email:

--- a/.github/workflows/wordpressRelease.yml
+++ b/.github/workflows/wordpressRelease.yml
@@ -6,7 +6,7 @@ on:
 env:
   PLUGIN_NAME: woo-better-shipping-calculator-for-brazil
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "4.1.4"
+  DEPLOY_TAG: "4.1.5"
 
 jobs:
   deploy-to-wp:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 4.1.5 - 22/05/25
 * Ajuste: campo de ocultação de endereço.
+* Inserção: dos contribuidores do plugin.
+* Inserção: de link que leva para página de configurações do plugin na página do carrinho apenas quando o usuário for administrador.
 
 # 4.1.4 - 20/05/25
 * Ajuste: campo de bairro está fora dos parâmetros estabelecidos.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 4.1.5 - 22/05/25
+* Ajuste: campo de ocultação de endereço.
+
 # 4.1.4 - 20/05/25
 * Ajuste: campo de bairro está fora dos parâmetros estabelecidos.
 * Ajuste: tags do arquivo README.txt.

--- a/Includes/WcBetterShippingCalculatorForBrazil.php
+++ b/Includes/WcBetterShippingCalculatorForBrazil.php
@@ -215,14 +215,15 @@ class WcBetterShippingCalculatorForBrazil
         $customer = WC()->customer;
 
         $cep_required = get_option('woo_better_calc_cep_required', 'yes');
+        $hidden_address = get_option('woo_better_hidden_cart_address', 'yes');
 
         // Verificar se o cliente está definido
         if (is_a($customer, 'WC_Customer')) {
-            if ($customer->get_shipping_city() === '' && $cep_required === 'yes') {
+            if ($customer->get_shipping_city() === '' && $cep_required === 'yes' && $hidden_address === 'yes') {
                 $customer->set_shipping_country('BR');
                 $customer->set_shipping_state('SP');
-                $customer->set_shipping_city('Exemplo');
-                $customer->set_shipping_address('Exemplo');
+                $customer->set_shipping_city('Vazio');
+                $customer->set_shipping_address('Vazio');
 
                 $customer->save();
             }

--- a/Includes/WcBetterShippingCalculatorForBrazil.php
+++ b/Includes/WcBetterShippingCalculatorForBrazil.php
@@ -79,7 +79,7 @@ class WcBetterShippingCalculatorForBrazil
         if (defined('WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_VERSION')) {
             $this->version = WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_VERSION;
         } else {
-            $this->version = '4.1.4';
+            $this->version = '4.1.5';
         }
         $this->plugin_name = 'wc-better-shipping-calculator-for-brazil';
 

--- a/Public/WcBetterShippingCalculatorForBrazilPublic.php
+++ b/Public/WcBetterShippingCalculatorForBrazilPublic.php
@@ -113,6 +113,21 @@ class WcBetterShippingCalculatorForBrazilPublic
 
         if (has_block('woocommerce/cart')) {
 
+            if (current_user_can('manage_options')) {
+                error_log('entreiiii');
+                wp_enqueue_script(
+                    $this->plugin_name . '-gutenberg-cep-settings-link',
+                    plugin_dir_url(__FILE__) . 'js/WcBetterShippingCalculatorForBrazilPublicGutenbergSettingsLink.js',
+                    array(),
+                    $this->version,
+                    false
+                );
+
+                wp_localize_script($this->plugin_name . '-gutenberg-cep-settings-link', 'lknCartData', array(
+                    'settingsUrl' => admin_url('admin.php?page=wc-settings&tab=wc-better-calc'),
+                ));
+            }
+
             if ($cep_required === 'yes') {
                 wp_enqueue_script(
                     $this->plugin_name . '-gutenberg-cep-field',

--- a/Public/WcBetterShippingCalculatorForBrazilPublic.php
+++ b/Public/WcBetterShippingCalculatorForBrazilPublic.php
@@ -114,7 +114,6 @@ class WcBetterShippingCalculatorForBrazilPublic
         if (has_block('woocommerce/cart')) {
 
             if (current_user_can('manage_options')) {
-                error_log('entreiiii');
                 wp_enqueue_script(
                     $this->plugin_name . '-gutenberg-cep-settings-link',
                     plugin_dir_url(__FILE__) . 'js/WcBetterShippingCalculatorForBrazilPublicGutenbergSettingsLink.js',

--- a/Public/WcBetterShippingCalculatorForBrazilPublic.php
+++ b/Public/WcBetterShippingCalculatorForBrazilPublic.php
@@ -126,7 +126,8 @@ class WcBetterShippingCalculatorForBrazilPublic
                     $woo_version_type = version_compare(WC_VERSION, '9.6.0', '>=') ? 'woo-block' : 'woo-class';
 
                     wp_localize_script($this->plugin_name . '-gutenberg-cep-field', 'WooBetterData', [
-                        'wooVersion' => $woo_version_type
+                        'wooVersion' => $woo_version_type,
+                        'wooHiddenAddress' => $hidden_address,
                     ]);
                 }
             }

--- a/Public/js/WcBetterShippingCalculatorForBrazilPublicGutenbergCEPField.js
+++ b/Public/js/WcBetterShippingCalculatorForBrazilPublicGutenbergCEPField.js
@@ -4,15 +4,15 @@ document.addEventListener('DOMContentLoaded', function () {
     let cepFound = false
     let previousCep = ''
     let continueButtonFound = false
-    let errorRequest = true
     let iconSummary = null
     let addressSummary = null
-    let previousText = ''
+    let postcodeError = false
     let postcodeValue = ''
     let continueButton = null
     let requestRepeated = false
+    let countRequest = 1
+    let countRequestTimeOut = null
 
-    let batchRequested = false
     let addressData = ''
     let stateData = ''
     let cityData = ''
@@ -55,6 +55,19 @@ document.addEventListener('DOMContentLoaded', function () {
     async function handleSubmitClick(continueButton) {
         const postcodeField = document.querySelector('.wc-block-components-text-input.wc-block-components-address-form__postcode');
         const inputPostcode = postcodeField ? postcodeField.querySelector('input') : null;
+        //  TODO aqui!!
+
+        if (typeof WooBetterData !== 'undefined' && WooBetterData.wooHiddenAddress === 'no') {
+            const cityBlock = document.querySelector('.wc-block-components-text-input.wc-block-components-address-form__city');
+            if (cityBlock) {
+                const inputCity = cityBlock.querySelector('input');
+                if (inputCity && inputCity.value === '') {
+                    alert('Campo cidade vazio');
+                    inputCity.focus();
+                    return;
+                }
+            }
+        }
 
         if (blockObserver instanceof MutationObserver) {
             blockObserver.disconnect();
@@ -87,8 +100,6 @@ document.addEventListener('DOMContentLoaded', function () {
                 postcodeValue = inputPostcode.value
                 if (inputPostcode.value !== previousCep) {
                     requestRepeated = false
-                    batchRequested = false
-                    errorRequest = false
 
                     addressSummary.addEventListener('click', blockInteraction, true);
                     addressSummary.classList.add('lkn-wc-shipping-address-summary');
@@ -97,13 +108,6 @@ document.addEventListener('DOMContentLoaded', function () {
                     const spinner = addressSummary.querySelector('.spinner');
                     if (!spinner) {
                         addressSummary.insertAdjacentHTML('beforeend', '<span class="spinner is-active"></span>');
-                    }
-                    const strongElement = addressSummary.querySelector('strong');
-
-                    if (strongElement) {
-                        previousText = strongElement.textContent;
-                    } else {
-                        previousText = 'old'
                     }
 
                     enableRequest = setInterval(() => {
@@ -212,71 +216,102 @@ document.addEventListener('DOMContentLoaded', function () {
         window.fetch = async function (url, options) {
 
             if (url.includes('/wp-json/wc/store/v1/batch')) {
-                if (!batchRequested && isValidCEP(postcodeValue)) {
+                if (!postcodeValue) {
+                    const postcodeField = document.querySelector('.wc-block-components-text-input.wc-block-components-address-form__postcode');
+                    if (postcodeField) {
+                        const inputPostcode = postcodeField ? postcodeField.querySelector('input') : null;
+                        if (inputPostcode) {
+                            postcodeValue = inputPostcode.value
+                        }
+                    }
+                }
+
+                if (isValidCEP(postcodeValue)) {
 
                     if (enableRequest) {
                         clearInterval(enableRequest);
                         enableRequest = null
                     }
 
-                    if (addressSummary) {
-                        const summaryBlock = document.querySelector('.wc-block-components-totals-shipping-panel');
-                        if (summaryBlock) {
-                            iconSummary = summaryBlock.querySelector('.wc-block-components-panel__button-icon');
-                            if (iconSummary) {
-                                iconSummary.addEventListener('click', blockInteraction, true);
-                            }
+                    const summaryBlock = document.querySelector('.wc-block-components-totals-shipping-panel');
+                    if (summaryBlock) {
+                        iconSummary = summaryBlock.querySelector('.wc-block-components-panel__button-icon');
+                        if (iconSummary) {
+                            iconSummary.addEventListener('click', blockInteraction, true);
                         }
+                    }
 
-                        if (!requestRepeated) {
-                            const apiUrl = `/wp-json/lknwcbettershipping/v1/cep/?postcode=${postcodeValue}`;
+                    if (!requestRepeated) {
+                        requestRepeated = true
+                        const apiUrl = `/wp-json/lknwcbettershipping/v1/cep/?postcode=${postcodeValue}`;
 
-                            batchRequested = true
+                        const controller = new AbortController();
+                        const timeoutId = setTimeout(() => controller.abort(), 10000); // 10 segundos
 
-                            const controller = new AbortController();
-                            const timeoutId = setTimeout(() => controller.abort(), 10000); // 10 segundos
+                        await fetch(apiUrl, {
+                            method: 'GET',
+                            signal: controller.signal,
+                            headers: {
+                                'Content-Type': 'application/json'
+                            }
+                        })
+                            .then(response => response.json())
+                            .then(data => {
+                                clearTimeout(timeoutId); // Se deu certo, limpa o timeout
 
-                            await fetch(apiUrl, {
-                                method: 'GET',
-                                signal: controller.signal,
-                                headers: {
-                                    'Content-Type': 'application/json'
-                                }
-                            })
-                                .then(response => response.json())
-                                .then(data => {
-                                    clearTimeout(timeoutId); // Se deu certo, limpa o timeout
+                                if (data.status === true) {
+                                    if (options && options.body) {
+                                        if (!data.address || !data.state_sigla || !data.city) {
+                                            postcodeError = true
+                                            if (addressSummary) {
+                                                removeLoading(addressSummary);
+                                                addressSummary.removeEventListener('click', blockInteraction, true);
+                                            }
+                                            if (iconSummary) {
+                                                iconSummary.removeEventListener('click', blockInteraction, true);
+                                            }
 
-                                    if (data.status === true) {
-                                        if (options && options.body) {
-                                            addressData = data.address ? data.address : ' ';
-                                            stateData = data.state_sigla;
-                                            cityData = data.city ? data.city : ' ';
+                                            if (!data.address) {
+                                                return alert('Erro: Endereço inválido.');
+                                            }
+
+                                            if (!data.state_sigla) {
+                                                return alert('Erro: Estado inválido.');
+                                            }
+
+                                            if (!data.city) {
+                                                return alert('Erro: Cidade inválida.');
+                                            }
+                                        } else {
+                                            postcodeError = false
                                         }
-                                    } else {
-                                        alert('Erro: ' + data.message);
-                                        removeLoading(addressSummary);
-                                        addressSummary.removeEventListener('click', blockInteraction, true);
-                                        if (iconSummary) {
-                                            iconSummary.removeEventListener('click', blockInteraction, true);
-                                        }
-                                        errorRequest = true;
+
+                                        addressData = data.address;
+                                        stateData = data.state_sigla;
+                                        cityData = data.city;
                                     }
-                                })
-                                .catch(error => {
-                                    clearTimeout(timeoutId); // Também limpa o timeout no erro
-                                    if (error.name === 'AbortError') {
-                                        alert('Erro: Tempo limite de resposta excedido.');
-                                    } else {
-                                        console.error(error);
-                                    }
+                                } else {
+                                    alert('Erro: ' + data.message);
                                     removeLoading(addressSummary);
                                     addressSummary.removeEventListener('click', blockInteraction, true);
                                     if (iconSummary) {
                                         iconSummary.removeEventListener('click', blockInteraction, true);
                                     }
-                                });
-                        }
+                                }
+                            })
+                            .catch(error => {
+                                clearTimeout(timeoutId); // Também limpa o timeout no erro
+                                if (error.name === 'AbortError') {
+                                    alert('Erro: Tempo limite de resposta excedido.');
+                                } else {
+                                    console.error(error);
+                                }
+                                removeLoading(addressSummary);
+                                addressSummary.removeEventListener('click', blockInteraction, true);
+                                if (iconSummary) {
+                                    iconSummary.removeEventListener('click', blockInteraction, true);
+                                }
+                            });
                     }
 
                 }
@@ -290,7 +325,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
                     if (updateCustomerRequest) {
 
-                        if (addressData !== '') {
+                        if (addressData !== '' && WooBetterData.wooHiddenAddress === 'yes' && !postcodeError) {
                             updateCustomerRequest.data.shipping_address.address_1 = addressData
                             updateCustomerRequest.body.shipping_address.address_1 = addressData
                             if (!updateCustomerRequest.data.billing_address) {
@@ -303,178 +338,87 @@ document.addEventListener('DOMContentLoaded', function () {
                             updateCustomerRequest.body.billing_address.address_1 = addressData
                         }
 
-                        if (stateData !== '') {
+                        if (stateData !== '' && WooBetterData.wooHiddenAddress === 'yes') {
                             updateCustomerRequest.data.shipping_address.state = stateData
                             updateCustomerRequest.body.shipping_address.state = stateData
                             updateCustomerRequest.data.billing_address.state = stateData
                             updateCustomerRequest.body.billing_address.state = stateData
                         }
 
-                        if (cityData !== '') {
+                        if (cityData !== '' && WooBetterData.wooHiddenAddress === 'yes') {
                             updateCustomerRequest.data.shipping_address.city = cityData
                             updateCustomerRequest.body.shipping_address.city = cityData
                             updateCustomerRequest.data.billing_address.city = cityData
                             updateCustomerRequest.body.billing_address.city = cityData
                         }
 
-                        if (addressData !== '' && stateData !== '' && cityData !== '' && !errorRequest) {
-
-                            blockObserver = new MutationObserver((mutationsList) => {
-                                for (const mutation of mutationsList) {
-                                    if (
-                                        mutation.type === 'childList' ||
-                                        mutation.type === 'characterData' ||
-                                        mutation.type === 'subtree'
-                                    ) {
-
-                                        let pComponent = addressSummary.querySelector('p');
-
-                                        if (!pComponent) {
-                                            let newP = document.createElement('p');
-                                            newP.style.margin = '0';
-
-                                            newP.textContent = responseText ? responseText : '';
-
-                                            const spanSummary = addressSummary.querySelector('span:not(.spinner)');
-                                            if (spanSummary) {
-                                                const textNode = Array.from(addressSummary.childNodes).find(node => node.nodeType === Node.TEXT_NODE);
-
-                                                if (textNode) {
-                                                    addressSummary.removeChild(textNode);
-                                                }
-
-                                                addressSummary.insertBefore(newP, spanSummary);
-                                            } else {
-                                                if (addressSummary && addressSummary.tagName === 'SPAN') {
-                                                    const textNode = Array.from(addressSummary.childNodes).find(node => node.nodeType === Node.TEXT_NODE);
-
-                                                    if (textNode) {
-                                                        addressSummary.removeChild(textNode);
-                                                    }
-                                                    addressSummary.appendChild(newP);
-                                                } else {
-                                                    addressSummary.appendChild(newP);
-                                                }
-                                            }
-                                        }
-
-
-                                        const strongELement = addressSummary.querySelector('strong');
-                                        if (strongELement) {
-                                            addressSummary.removeChild(strongELement);
-                                        }
-
-                                        if (addressSummary && addressSummary.tagName === 'SPAN') {
-                                            const textNode = Array.from(addressSummary.childNodes).find(node => node.nodeType === Node.TEXT_NODE);
-
-                                            if (textNode) {
-                                                addressSummary.removeChild(textNode);
-                                            }
-                                        }
-                                    }
-                                }
-                            });
-
-                            blockObserver.observe(addressSummary, {
-                                childList: true,
-                                characterData: true,
-                                subtree: true
-                            });
-
-                            const previousPostcode = document.querySelector('.wc-block-components-address-form__postcode');
-                            const inputPreviousPostcode = previousPostcode ? previousPostcode.querySelector('input') : null;
-
-                            let pComponent = addressSummary.querySelector('p');
-
-                            if (!pComponent) {
-                                let newP = document.createElement('p');
-                                newP.style.margin = '0';
-
-                                const spanSummary = addressSummary.querySelector('span:not(.spinner)');
-                                if (spanSummary) {
-                                    const textNode = Array.from(addressSummary.childNodes).find(node => node.nodeType === Node.TEXT_NODE);
-
-                                    if (textNode) {
-                                        addressSummary.removeChild(textNode);
-                                    }
-
-                                    addressSummary.insertBefore(newP, spanSummary);
-                                } else {
-                                    if (addressSummary && addressSummary.tagName === 'SPAN') {
-                                        const textNode = Array.from(addressSummary.childNodes).find(node => node.nodeType === Node.TEXT_NODE);
-
-                                        if (textNode) {
-                                            addressSummary.removeChild(textNode);
-                                        }
-                                        addressSummary.appendChild(newP);
-                                    } else {
-                                        addressSummary.appendChild(newP);
-                                    }
-                                }
-                            }
-
-                            newP = addressSummary.querySelector('p');
-
-                            if (previousText && newP) {
-                                if (typeof WooBetterData !== 'undefined' && WooBetterData.wooVersion === 'woo-block') {
-                                    responseText = `${postcodeValue}, ${cityData}, ${stateData}, Brasil `
-                                } else {
-                                    responseText = `Entrega em ${postcodeValue}, ${cityData}, ${stateData}, Brasil `
-                                }
-
-                                if (postcodeValue !== previousCep) {
-
-                                    newP.textContent = responseText;
-                                    removeLoading(addressSummary);
-                                    previousText = newP.textContent;
-                                    enableButton(continueButton);
-                                    if (inputPreviousPostcode) {
-                                        previousCep = inputPreviousPostcode.value;
-                                    }
-                                }
-
-                                if (addressSummary) {
-                                    addressSummary.removeEventListener('click', blockInteraction, true);
-                                }
-                                if (iconSummary) {
-                                    iconSummary.removeEventListener('click', blockInteraction, true);
-                                }
-                            } else {
-                                removeLoading(addressSummary)
-                                if (addressSummary) {
-                                    addressSummary.removeEventListener('click', blockInteraction, true);
-                                }
-                                if (iconSummary) {
-                                    iconSummary.removeEventListener('click', blockInteraction, true);
-                                }
-                            }
-                        } else {
-                            removeLoading(addressSummary)
-                            if (addressSummary) {
-                                addressSummary.removeEventListener('click', blockInteraction, true);
-                            }
-                            if (iconSummary) {
-                                iconSummary.removeEventListener('click', blockInteraction, true);
-                            }
-                        }
-
                         options.body = JSON.stringify(requestData);
                     }
                 } catch (err) {
                     console.error('Erro ao modificar o body: ', err);
-                    removeLoading(addressSummary)
                     if (addressSummary) {
+                        removeLoading(addressSummary)
                         addressSummary.removeEventListener('click', blockInteraction, true);
                     }
                     if (iconSummary) {
                         iconSummary.removeEventListener('click', blockInteraction, true);
                     }
                 }
+
+                const result = originalFetch(url, options);
+
+                return result.then(async function (response) {
+                    if (!postcodeError) {
+                        if (countRequest === 1) {
+                            countRequestTimeOut = setTimeout(async () => {
+                                countRequest = 0
+                                await removeInteractionEvents();
+                                resetAddressInteraction();
+                            }, 4000);
+                        } else if (countRequest > 1) {
+                            clearTimeout(countRequestTimeOut);
+                            countRequest = 0
+                            await removeInteractionEvents();
+                            resetAddressInteraction();
+                        }
+
+                        countRequest++;
+                    }
+                    return response;
+                }).catch(error => {
+                    console.error('Erro na requisição:', error);
+                    throw error;
+                });
             }
 
             // Sempre chama o fetch original
             return originalFetch(url, options);
-        };
+
+        }
+    }
+
+    async function removeInteractionEvents() {
+        if (typeof WooBetterData !== 'undefined' && WooBetterData.wooVersion === 'woo-block') {
+            addressSummary = document.querySelector('.wc-block-components-totals-shipping-address-summary');
+        } else if (WooBetterData.wooVersion === 'woo-class') {
+            await waitForShippingBlock();
+        }
+
+        if (addressSummary) {
+            addressSummary.removeEventListener('click', blockInteraction, true);
+        }
+        if (iconSummary) {
+            iconSummary.removeEventListener('click', blockInteraction, true);
+        }
+    }
+
+    function resetAddressInteraction() {
+        removeLoading(addressSummary);
+        enableButton(continueButton);
+        addressData = '';
+        stateData = '';
+        cityData = '';
+        countRequestTimeOut = null;
     }
 
     async function waitForShippingBlock() {
@@ -486,7 +430,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     addressSummary = shippingBlock
                     clearInterval(shippingBlockInterval);
                     resolve();
-                } else if (shippingBlockIntervalCount >= 20) {
+                } else if (shippingBlockIntervalCount >= 40) {
                     clearInterval(shippingBlockInterval);
                     resolve();
                 }
@@ -523,15 +467,40 @@ document.addEventListener('DOMContentLoaded', function () {
                 clearTimeout(timeoutId); // Se deu certo, limpa o timeout
 
                 if (data.status === true) {
+                    if (!data.address || !data.state_sigla || !data.city) {
+                        postcodeError = true
+                        if (addressSummary) {
+                            removeLoading(addressSummary);
+                            addressSummary.removeEventListener('click', blockInteraction, true);
+                            if (iconSummary) {
 
-                    const addressData = data.address ? data.address : ' ';
-                    const stateData = data.state_sigla;
-                    const cityData = data.city ? data.city : ' ';
+                            }
+                            iconSummary.removeEventListener('click', blockInteraction, true);
+                        }
+
+                        if (!data.address) {
+                            return alert('Erro: Endereço inválido.');
+                        }
+
+                        if (!data.state_sigla) {
+                            return alert('Erro: Estado inválido.');
+                        }
+
+                        if (!data.city) {
+                            return alert('Erro: Cidade inválida.');
+                        }
+                    } else {
+                        postcodeError = false
+                    }
+
+                    addressData = data.address;
+                    stateData = data.state_sigla;
+                    cityData = data.city;
 
                     let wooNonce = ''
                     let wpNonce = ''
 
-                    if (wpApiSettings.nonce) {
+                    if (typeof wpApiSettings !== 'undefined' && wpApiSettings?.nonce) {
                         wpNonce = wpApiSettings.nonce
                     }
 
@@ -587,24 +556,6 @@ document.addEventListener('DOMContentLoaded', function () {
                             ]
                         })
                     })
-                        .then(data => {
-                            enableButton(continueButton)
-                            removeLoading(addressSummary);
-                            addressSummary.removeEventListener('click', blockInteraction, true);
-                            if (iconSummary) {
-                                iconSummary.removeEventListener('click', blockInteraction, true);
-                            }
-                        })
-                        .catch(error => {
-                            alert('Erro: ' + error?.message);
-                            removeLoading(addressSummary);
-                            addressSummary.removeEventListener('click', blockInteraction, true);
-                            if (iconSummary) {
-                                iconSummary.removeEventListener('click', blockInteraction, true);
-                            }
-                            errorRequest = true;
-                        });
-
                 } else {
                     alert('Erro: ' + data.message);
                     removeLoading(addressSummary);
@@ -612,7 +563,6 @@ document.addEventListener('DOMContentLoaded', function () {
                     if (iconSummary) {
                         iconSummary.removeEventListener('click', blockInteraction, true);
                     }
-                    errorRequest = true;
                 }
             })
             .catch(error => {

--- a/Public/js/WcBetterShippingCalculatorForBrazilPublicGutenbergCEPField.js
+++ b/Public/js/WcBetterShippingCalculatorForBrazilPublicGutenbergCEPField.js
@@ -55,7 +55,6 @@ document.addEventListener('DOMContentLoaded', function () {
     async function handleSubmitClick(continueButton) {
         const postcodeField = document.querySelector('.wc-block-components-text-input.wc-block-components-address-form__postcode');
         const inputPostcode = postcodeField ? postcodeField.querySelector('input') : null;
-        //  TODO aqui!!
 
         if (typeof WooBetterData !== 'undefined' && WooBetterData.wooHiddenAddress === 'no') {
             const cityBlock = document.querySelector('.wc-block-components-text-input.wc-block-components-address-form__city');
@@ -464,7 +463,7 @@ document.addEventListener('DOMContentLoaded', function () {
         })
             .then(response => response.json())
             .then(data => {
-                clearTimeout(timeoutId); // Se deu certo, limpa o timeout
+                clearTimeout(timeoutId);
 
                 if (data.status === true) {
                     if (!data.address || !data.state_sigla || !data.city) {

--- a/Public/js/WcBetterShippingCalculatorForBrazilPublicGutenbergSettingsLink.js
+++ b/Public/js/WcBetterShippingCalculatorForBrazilPublicGutenbergSettingsLink.js
@@ -1,0 +1,40 @@
+function insertSettingsLink() {
+    let submitBlockFound = false
+    const submitBlock = document.querySelector('.wc-block-cart__submit');
+
+    if (!submitBlock) {
+        submitBlockFound = false;
+        return;
+    }
+
+    // Garante que o elemento existe e evita duplicação do link
+    if (submitBlock && typeof lknCartData !== 'undefined' && !submitBlock.querySelector('.lkn-settings-link') && !submitBlockFound) {
+        submitBlockFound = true;
+        const link = document.createElement('a');
+        link.href = lknCartData.settingsUrl;
+        link.textContent = 'Ir para Configurações da Calculadora de Frete';
+        link.className = 'lkn-settings-link';
+        link.style.marginTop = '10px';
+        link.style.display = 'block';
+        link.style.color = '#0073aa';
+        link.style.textDecoration = 'none';
+
+        submitBlock.appendChild(link);
+    }
+}
+
+// Observer para detectar alterações no DOM
+const observer = new MutationObserver(() => {
+    insertSettingsLink();
+});
+
+// Inicia o observer após o DOM estar pronto
+document.addEventListener('DOMContentLoaded', () => {
+    observer.observe(document.body, {
+        childList: true,
+        subtree: true
+    });
+
+    // Tenta inserir imediatamente também
+    insertSettingsLink();
+});

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Calculadora de frete melhorada para lojas brasileiras
 
-* Contribuidores: LinkNacional
+* Contribuidores: LinkNacional, luizbills
 * Link para doações: [LinkNacional](https://www.linknacional.com.br/)
 * Tags: woocommerce, brasil, calculadora de frete, CEP, entrega
 * Testado até: 6.8

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 * Tags: woocommerce, brasil, calculadora de frete, CEP, entrega
 * Testado até: 6.8
 * Requer PHP: 7.3
-* Tag estável: 4.1.4
+* Tag estável: 4.1.5
 * Licença: GPLv2 ou posterior
 * URI da licença: [https://www.gnu.org/licenses/gpl-2.0.html](https://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/README.txt
+++ b/README.txt
@@ -1,5 +1,5 @@
 === Calculadora de Frete para o Brasil ===
-Contributors: LinkNacional
+Contributors: LinkNacional, luizbills
 Donate link:
 Tags: woocommerce, brasil, calculadora de frete, CEP, entrega
 Requires at least: 4.6
@@ -84,6 +84,8 @@ add_filter(
 
 = 4.1.5 - 22/05/2025 =
 * Ajuste: campo de ocultação de endereço.
+* Inserção: dos contribuidores do plugin.
+* Inserção: de link que leva para página de configurações do plugin na página do carrinho apenas quando o usuário for administrador.
 
 = 4.1.4 - 20/05/2025 =
 * Ajuste: campo de bairro está fora dos parâmetros estabelecidos.

--- a/README.txt
+++ b/README.txt
@@ -82,6 +82,9 @@ add_filter(
 
 == Changelog ==
 
+= 4.1.5 - 22/05/2025 =
+* Ajuste: campo de ocultação de endereço.
+
 = 4.1.4 - 20/05/2025 =
 * Ajuste: campo de bairro está fora dos parâmetros estabelecidos.
 * Ajuste: tags do arquivo README.txt.

--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: woocommerce, brasil, calculadora de frete, CEP, entrega
 Requires at least: 4.6
 Tested up to: 6.8
 Requires PHP: 7.3
-Stable tag: 4.1.4
+Stable tag: 4.1.5
 License: GPLv2 or later
 License URI: [https://www.gnu.org/licenses/gpl-2.0.html](https://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/README.txt
+++ b/README.txt
@@ -28,7 +28,7 @@ Calculadora de frete melhorada para lojas brasileiras, facilitando e melhorando 
 - Ocultação de campos de endereço.
 - Compatibilidade com o modo Legacy e Blocos (Gutenberg).
 
-Algumas dessas funcionalidades podem ser modificadas ou desativadas usando hooks. Mais detalhes na seção [Perguntas Frequentes (FAQ)](#faq).
+Algumas dessas funcionalidades podem ser modificadas ou desativadas usando hooks. Mais detalhes na seção [Perguntas Frequentes (FAQ)](https://wordpress.org/support/plugin/woo-better-shipping-calculator-for-brazil/).
 
 = Help and Support =
 

--- a/RESUMELOG.md
+++ b/RESUMELOG.md
@@ -1,5 +1,9 @@
 # 4.1.5 - 22/05/25
 * Ajuste: campo de ocultação de endereço.
+* Inserção: dos contribuidores do plugin.
+* Inserção: de link que leva para página de configurações do plugin na página do carrinho apenas quando o usuário for administrador.
+
+![image](https://github.com/user-attachments/assets/8c5b6e61-a87d-491f-9b4c-8a6712f20bba)
 
 # 4.1.4 - 20/05/25
 * Ajuste: campo de bairro está fora dos parâmetros estabelecidos.

--- a/RESUMELOG.md
+++ b/RESUMELOG.md
@@ -1,3 +1,6 @@
+# 4.1.5 - 22/05/25
+* Ajuste: campo de ocultação de endereço.
+
 # 4.1.4 - 20/05/25
 * Ajuste: campo de bairro está fora dos parâmetros estabelecidos.
 * Ajuste: tags do arquivo README.txt.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-php-dev-container",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "description": "This repository provides a development environment for WordPress",
   "repository": {
     "type": "git",

--- a/wc-better-shipping-calculator-for-brazil.php
+++ b/wc-better-shipping-calculator-for-brazil.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Calculadora de Frete para o Brasil
  * Plugin URI:        https://www.linknacional.com.br/wordpress
  * Description:       Calculadora automática de Frete com CEP para Woocommerce. Sem necessidade de informar o Pais e estado. Compatível com Gutenberg e shortcodes. Ideal para Lojas Brasileiras.
- * Version:           4.1.4
+ * Version:           4.1.5
  * Author:            Link Nacional
  * Author URI:        https://linknacional.com.br/
  * Requires PHP:      7.3
@@ -46,7 +46,7 @@ if (! defined('WPINC')) {
  */
 // Consts
 if (! defined('WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_VERSION')) {
-    define('WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_VERSION', '4.1.4');
+    define('WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_VERSION', '4.1.5');
 }
 
 if (! defined('WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_MIN_GIVE_VERSION')) {


### PR DESCRIPTION
# Calculadora de frete melhorada para lojas brasileiras

* Contribuidores: LinkNacional, luizbills
* Link para doações: [LinkNacional](https://www.linknacional.com.br/)
* Tags: woocommerce, brasil, calculadora de frete, CEP
* Testado até: 6.7
* Requer PHP: 7.3
* Tag estável: 4.1.5
* Licença: GPLv2 ou posterior
* URI da licença: [https://www.gnu.org/licenses/gpl-2.0.html](https://www.gnu.org/licenses/gpl-2.0.html)
* Traduções: Português(Brasil)

## Descrição

Calculadora de frete WooCommerce otimizada para lojas brasileiras:

> Na página de Carrinho:

- Validação de CEP.
- Controle no botão de envio, permitindo apenas seguir após inserir um CEP válido.
- Ocultação de campos de endereço.
- Compatibilidade com o modo Legacy e Blocos (Gutenberg).

> Na página de Checkout:

- Campo de número(complementando o endereço via `checkbox` ou `text-input`).
- Ocultação de campos de endereço.
- Compatibilidade com o modo Legacy e Blocos (Gutenberg).

Algumas dessas funcionalidades podem ser modificadas ou desativadas usando hooks. Mais detalhes na seção [Perguntas Frequentes (FAQ)](https://wordpress.org/support/plugin/woo-better-shipping-calculator-for-brazil/).

## Como instalar?

1. Acesse o painel de administração do WordPress e vá para **Plugins > Adicionar Novo**.
2. Pesquise por "Calculadora de frete melhorada para lojas brasileiras".
3. Encontre o plugin, clique em **Instalar Agora** e depois em **Ativar**.
4. Pronto! Nenhuma configuração adicional é necessária.

## Resumo(4.1.5):

> Ajustes nos campos de endereço carrinho, melhorando a verificação dos campos no momento em que o usuário decide manter os campos de endereço.

> Inserção dos contribuidores do plugin. 

> Inserção de link que leva para página de configurações do plugin na página do carrinho apenas quando o usuário for administrador:

![image](https://github.com/user-attachments/assets/8c5b6e61-a87d-491f-9b4c-8a6712f20bba)
