### PR TITLE
4.2.1 - woo-better-shipping-calculator-for-brazil (Correção na URL dinâmica, exibição da barra de progresso e verificação de CEP válido) 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 env:
   PLUGIN_NAME: woo-better-shipping-calculator-for-brazil
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "4.2.0"
+  DEPLOY_TAG: "4.2.1"
 jobs:
   release-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/resumeLog.yml
+++ b/.github/workflows/resumeLog.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   PLUGIN_NAME: woo-better-shipping-calculator-for-brazil
-  TITLE: "Opção para definir um valor mínimo para frete gratuito e novo layout"
+  TITLE: "Correção na URL dinâmica, barra de progresso e melhorias de performance"
   VERSION: "4.2.1"
 
 jobs:

--- a/.github/workflows/resumeLog.yml
+++ b/.github/workflows/resumeLog.yml
@@ -6,7 +6,7 @@ on:
 env:
   PLUGIN_NAME: woo-better-shipping-calculator-for-brazil
   TITLE: "Opção para definir um valor mínimo para frete gratuito e novo layout"
-  VERSION: "4.2.0"
+  VERSION: "4.2.1"
 
 jobs:
   send-email:

--- a/.github/workflows/wordpressRelease.yml
+++ b/.github/workflows/wordpressRelease.yml
@@ -6,7 +6,7 @@ on:
 env:
   PLUGIN_NAME: woo-better-shipping-calculator-for-brazil
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "4.2.0"
+  DEPLOY_TAG: "4.2.1"
 
 jobs:
   deploy-to-wp:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 4.2.1 - 09/06/25
+* Correção: Separador de decimal.
+* Correção: URL dinâmica.
+* Correção: Barra de progresso na página legacy do carrinho.
+
 # 4.2.0 - 06/06/25
 * Adição: Opção para definir um valor mínimo para frete gratuito.
 

--- a/Includes/WcBetterShippingCalculatorForBrazil.php
+++ b/Includes/WcBetterShippingCalculatorForBrazil.php
@@ -79,7 +79,7 @@ class WcBetterShippingCalculatorForBrazil
         if (defined('WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_VERSION')) {
             $this->version = WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_VERSION;
         } else {
-            $this->version = '4.2.0';
+            $this->version = '4.2.1';
         }
         $this->plugin_name = 'wc-better-shipping-calculator-for-brazil';
 

--- a/Public/WcBetterShippingCalculatorForBrazilPublic.php
+++ b/Public/WcBetterShippingCalculatorForBrazilPublic.php
@@ -143,6 +143,7 @@ class WcBetterShippingCalculatorForBrazilPublic
                     wp_localize_script($this->plugin_name . '-gutenberg-cep-field', 'WooBetterData', [
                         'wooVersion' => $woo_version_type,
                         'wooHiddenAddress' => $hidden_address,
+                        'wooUrl' => home_url()
                     ]);
                 }
             }

--- a/Public/js/WcBetterShippingCalculatorForBrazilProgressBar.js
+++ b/Public/js/WcBetterShippingCalculatorForBrazilProgressBar.js
@@ -16,7 +16,22 @@
 			el = document.querySelector('.cart-subtotal .woocommerce-Price-amount.amount bdi');
 		}
 		if (!el) return 0;
-		let value = el.textContent.replace(/[^\d,.-]/g, '').replace('.', '').replace(',', '.');
+
+		// Obtém as configurações de moeda do WooCommerce
+		const currencySettings = window.wcSettings?.currency || {};
+		const decimalSeparator = currencySettings.decimalSeparator || ',';
+		const thousandSeparator = currencySettings.thousandSeparator || '.';
+
+		// Força os separadores padrão se forem diferentes
+		const effectiveDecimalSeparator = decimalSeparator === '.' || decimalSeparator === ',' ? decimalSeparator : ',';
+		const effectiveThousandSeparator = thousandSeparator === '.' || thousandSeparator === ',' ? thousandSeparator : '.';
+
+		// Converte o valor do texto para número
+		let value = el.textContent
+			.replace(new RegExp(`\\${effectiveThousandSeparator}`, 'g'), '') // Remove o separador de milhar
+			.replace(new RegExp(`\\${effectiveDecimalSeparator}`), '.') // Substitui o separador decimal por '.'
+			.replace(/[^\d.-]/g, ''); // Remove caracteres não numéricos
+
 		return parseFloat(value) || 0;
 	}
 
@@ -32,7 +47,7 @@
 			percent = Math.min((cartTotal / minValue) * 100, 100);
 			message = cartTotal >= minValue
 				? 'Parabéns! Você tem frete grátis!'
-				: 'Falta(m) apenas mais R$' + (minValue - cartTotal).toFixed(2) + ' em compra para FRETE GRÀTIS';
+				: 'Falta(m) apenas mais R$' + (minValue - cartTotal).toFixed(2) + ' para obter FRETE GRÀTIS';
 		}
 
 		let progressBar = document.querySelector('.wc-better-shipping-progress-bar');
@@ -71,7 +86,7 @@
 			progressBarContainer.appendChild(progressBarWrapper);
 			progressBarContainer.appendChild(progressBarText);
 
-			let targets = document.querySelectorAll('.cart_totals.calculated_shipping h2');
+			let targets = document.querySelectorAll('.cart-collaterals .cart_totals h2');
 			if (targets.length > 0) {
 				progressBarContainer.style.padding = '0px';
 				targets.forEach(function (target) {

--- a/Public/js/WcBetterShippingCalculatorForBrazilPublicGutenbergCEPField.js
+++ b/Public/js/WcBetterShippingCalculatorForBrazilPublicGutenbergCEPField.js
@@ -17,7 +17,6 @@ document.addEventListener('DOMContentLoaded', function () {
     let stateData = ''
     let cityData = ''
 
-    let responseText = '';
     let blockObserver = null
     let enableRequest = null
 
@@ -242,7 +241,16 @@ document.addEventListener('DOMContentLoaded', function () {
 
                     if (!requestRepeated) {
                         requestRepeated = true
-                        const apiUrl = wpApiSettings.root + `lknwcbettershipping/v1/cep/?postcode=${postcodeValue}`;
+                        let apiUrl = ''
+                        if (typeof wpApiSettings !== 'undefined' && wpApiSettings.root) {
+                            apiUrl = wpApiSettings.root + `lknwcbettershipping/v1/cep/?postcode=${postcodeValue}`;
+                        } else {
+                            if (typeof WooBetterData !== 'undefined' && WooBetterData.wooUrl !== '') {
+                                apiUrl = WooBetterData.wooUrl + `/wp-json/lknwcbettershipping/v1/cep/?postcode=${postcodeValue}`;
+                            } else {
+                                apiUrl = `/wp-json/lknwcbettershipping/v1/cep/?postcode=${postcodeValue}`;
+                            }
+                        }
 
                         const controller = new AbortController();
                         const timeoutId = setTimeout(() => controller.abort(), 10000); // 10 segundos
@@ -291,6 +299,7 @@ document.addEventListener('DOMContentLoaded', function () {
                                     }
                                 } else {
                                     alert('Erro: ' + data.message);
+                                    postcodeError = true;
                                     removeLoading(addressSummary);
                                     addressSummary.removeEventListener('click', blockInteraction, true);
                                     if (iconSummary) {
@@ -442,7 +451,15 @@ document.addEventListener('DOMContentLoaded', function () {
     async function batchRequest() {
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), 15000);
-        const apiUrl = wpApiSettings.root + `lknwcbettershipping/v1/cep/?postcode=${postcodeValue}`;
+        if (typeof wpApiSettings !== 'undefined' && wpApiSettings.root) {
+            apiUrl = wpApiSettings.root + `lknwcbettershipping/v1/cep/?postcode=${postcodeValue}`;
+        } else {
+            if (typeof WooBetterData !== 'undefined' && WooBetterData.wooUrl !== '') {
+                apiUrl = WooBetterData.wooUrl + `/wp-json/lknwcbettershipping/v1/cep/?postcode=${postcodeValue}`;
+            } else {
+                apiUrl = `/wp-json/lknwcbettershipping/v1/cep/?postcode=${postcodeValue}`;
+            }
+        }
 
         addressSummary.addEventListener('click', blockInteraction, true);
         addressSummary.classList.add('lkn-wc-shipping-address-summary');
@@ -507,7 +524,20 @@ document.addEventListener('DOMContentLoaded', function () {
                         wooNonce = wcBlocksMiddlewareConfig.storeApiNonce
                     }
 
-                    fetch(wpApiSettings.root + '/wc/store/v1/batch?_locale=site', {
+                    let batchUrl = ''
+
+                    if (typeof wpApiSettings !== 'undefined' && wpApiSettings.root) {
+                        batchUrl = wpApiSettings.root + `/wc/store/v1/batch?_locale=site`;
+                    } else {
+                        batchUrl = window.location.origin + `/wp-json/wc/store/v1/batch?_locale=site`;
+                        if (typeof WooBetterData !== 'undefined' && WooBetterData.wooUrl !== '') {
+                            apiUrl = WooBetterData.wooUrl + `/wp-json/wc/store/v1/batch?_locale=site`;
+                        } else {
+                            apiUrl = `/wp-json/wc/store/v1/batch?_locale=site`;
+                        }
+                    }
+
+                    fetch(batchUrl, {
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/json',
@@ -558,6 +588,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 } else {
                     alert('Erro: ' + data.message);
                     removeLoading(addressSummary);
+                    postcodeError = true;
                     addressSummary.removeEventListener('click', blockInteraction, true);
                     if (iconSummary) {
                         iconSummary.removeEventListener('click', blockInteraction, true);

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 * Tags: woocommerce, brasil, calculadora de frete, CEP, entrega
 * Testado até: 6.8
 * Requer PHP: 7.3
-* Tag estável: 4.2.0
+* Tag estável: 4.2.1
 * Licença: GPLv2 ou posterior
 * URI da licença: [https://www.gnu.org/licenses/gpl-2.0.html](https://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: woocommerce, brasil, calculadora de frete, CEP, entrega
 Requires at least: 4.6
 Tested up to: 6.8
 Requires PHP: 7.3
-Stable tag: 4.2.0
+Stable tag: 4.2.1
 License: GPLv2 or later
 License URI: [https://www.gnu.org/licenses/gpl-2.0.html](https://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/README.txt
+++ b/README.txt
@@ -91,6 +91,11 @@ add_filter(
 
 == Changelog ==
 
+= 4.2.1 - 09/06/2025 =
+* Fix: Decimal separator.
+* Fix: Dynamic URL.
+* Fix: Progress bar on the legacy cart page.
+
 = 4.2.0 - 06/06/2025 =
 * Addition: Option to set a minimum cart value for free shipping.
 

--- a/RESUMELOG.md
+++ b/RESUMELOG.md
@@ -1,3 +1,8 @@
+# 4.2.1 - 09/06/25
+* Correção: Separador de decimal.
+* Correção: URL dinâmica.
+* Correção: Barra de progresso na página legacy do carrinho.
+
 # 4.2.0 - 06/06/25
 * Adição: Opção para definir um valor mínimo para frete gratuito.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-php-dev-container",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "This repository provides a development environment for WordPress",
   "repository": {
     "type": "git",

--- a/wc-better-shipping-calculator-for-brazil.php
+++ b/wc-better-shipping-calculator-for-brazil.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Calculadora de Frete para o Brasil
  * Plugin URI:        https://www.linknacional.com.br/wordpress
  * Description:       Calculadora automática de Frete com CEP para Woocommerce. Sem necessidade de informar o Pais e estado. Compatível com Gutenberg e shortcodes. Ideal para Lojas Brasileiras.
- * Version:           4.2.0
+ * Version:           4.2.1
  * Author:            Link Nacional
  * Author URI:        https://linknacional.com.br/
  * Requires PHP:      7.3
@@ -46,7 +46,7 @@ if (! defined('WPINC')) {
  */
 // Consts
 if (! defined('WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_VERSION')) {
-    define('WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_VERSION', '4.2.0');
+    define('WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_VERSION', '4.2.1');
 }
 
 if (! defined('WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_MIN_GIVE_VERSION')) {


### PR DESCRIPTION
# Calculadora de frete melhorada para lojas brasileiras

* Contribuidores: LinkNacional, luizbills
* Link para doações: [LinkNacional](https://www.linknacional.com.br/)
* Tags: woocommerce, brasil, calculadora de frete, CEP
* Testado até: 6.7
* Requer PHP: 7.3
* Tag estável: 4.1.6
* Licença: GPLv2 ou posterior
* URI da licença: [https://www.gnu.org/licenses/gpl-2.0.html](https://www.gnu.org/licenses/gpl-2.0.html)
* Traduções: Português(Brasil)

## Descrição

Calculadora de frete WooCommerce otimizada para lojas brasileiras:

> Na página de Carrinho:

- Validação de CEP.
- Controle no botão de envio, permitindo apenas seguir após inserir um CEP válido.
- Ocultação de campos de endereço.
- Compatibilidade com o modo Legacy e Blocos (Gutenberg).

> Na página de Checkout:

- Campo de número(complementando o endereço via `checkbox` ou `text-input`).
- Ocultação de campos de endereço.
- Compatibilidade com o modo Legacy e Blocos (Gutenberg).

Algumas dessas funcionalidades podem ser modificadas ou desativadas usando hooks. Mais detalhes na seção [Perguntas Frequentes (FAQ)](https://wordpress.org/support/plugin/woo-better-shipping-calculator-for-brazil/).

## Como instalar?

1. Acesse o painel de administração do WordPress e vá para **Plugins > Adicionar Novo**.
2. Pesquise por "Calculadora de frete melhorada para lojas brasileiras".
3. Encontre o plugin, clique em **Instalar Agora** e depois em **Ativar**.
4. Pronto! Nenhuma configuração adicional é necessária.

## Resumo(4.2.1):

- Correção: Separador de decimal.
>
- Correção: URL dinâmica.
>
- Correção: Barra de progresso na página legacy do carrinho.
>