### PR TITLE
4.15.0 - woo-better-shipping-calculator-for-brazil (Novo: Formato para o CNPJ alfanumérico)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Ajuste: Classe has-error no campo de número do Gutenberg quando o campo tá vazio.
 * Ajuste: Preenchimento do CEP no autocomplete.
 * Ajuste: Nonce do campo de número de contato.
+* Ajuste: autopreenchimento de endereço na página do pedido.
 
 # 4.14.0 - 27/05/26
 * Novo: Recurso de preenchimento de CEP.

--- a/Includes/WcBetterShippingCalculatorForBrazil.php
+++ b/Includes/WcBetterShippingCalculatorForBrazil.php
@@ -171,6 +171,9 @@ class WcBetterShippingCalculatorForBrazil
         
         // Hook para sincronizar campo empresa quando meta de post é atualizada
         $this->loader->add_action('updated_post_meta', $this, 'sync_company_field_on_meta_update', 10, 4);
+
+        // Hook para adicionar campos customizados na resposta AJAX de detalhes do cliente (admin)
+        $this->loader->add_filter('woocommerce_ajax_get_customer_details', $this, 'add_custom_fields_to_customer_details', 10, 3);
     }
 
     public function lkn_show_admin_notice()
@@ -6919,5 +6922,64 @@ class WcBetterShippingCalculatorForBrazil
         }
         
         return $address;
+    }
+
+    /**
+     * Adiciona campos customizados brasileiros na resposta AJAX de detalhes do cliente.
+     *
+     * Disparado ao clicar em "Carregar endereço de cobrança/entrega" na edição de pedido no admin.
+     *
+     * @param array      $data     Dados do cliente já montados pelo WooCommerce.
+     * @param WC_Customer $customer Objeto do cliente.
+     * @param int        $user_id  ID do usuário.
+     * @return array
+     */
+    public function add_custom_fields_to_customer_details($data, $customer, $user_id)
+    {
+        if (!$user_id) {
+            return $data;
+        }
+
+        $person_type        = get_option('woo_better_calc_person_type_select', 'none');
+        $neighborhood_enabled = get_option('woo_better_calc_enable_neighborhood_field', 'no');
+        $number_enabled     = get_option('woo_better_calc_number_required', 'no');
+        $birthdate_enabled  = get_option('woo_better_calc_enable_birthdate_field', 'no');
+        $gender_enabled     = get_option('woo_better_calc_enable_gender_field', 'no');
+        $ie_field_enabled   = get_option('woo_better_calc_enable_ie_field', 'no');
+
+        // ── Billing ──────────────────────────────────────────────────────────
+        if ($person_type !== 'none') {
+            $billing_persontype = get_user_meta($user_id, 'billing_persontype', true);
+            $billing_cpf        = get_user_meta($user_id, 'billing_cpf', true);
+            $billing_cnpj       = get_user_meta($user_id, 'billing_cnpj', true);
+
+            $data['billing']['persontype'] = $billing_persontype;
+            $data['billing']['cpf']        = $billing_cpf;
+            $data['billing']['cnpj']       = $billing_cnpj;
+
+            if ($ie_field_enabled === 'yes' && ($person_type === 'legal' || $person_type === 'both')) {
+                $data['billing']['ie'] = get_user_meta($user_id, 'billing_ie', true);
+            }
+        }
+
+        if ($neighborhood_enabled === 'yes') {
+            $data['billing']['neighborhood']  = get_user_meta($user_id, 'billing_neighborhood', true);
+            $data['shipping']['neighborhood'] = get_user_meta($user_id, 'shipping_neighborhood', true);
+        }
+
+        if ($number_enabled === 'yes') {
+            $data['billing']['number']  = get_user_meta($user_id, 'billing_number', true);
+            $data['shipping']['number'] = get_user_meta($user_id, 'shipping_number', true);
+        }
+
+        if ($birthdate_enabled === 'yes') {
+            $data['billing']['birthdate'] = get_user_meta($user_id, 'billing_birthdate', true);
+        }
+
+        if ($gender_enabled === 'yes') {
+            $data['billing']['gender'] = get_user_meta($user_id, 'billing_gender', true);
+        }
+
+        return $data;
     }
 }

--- a/README.txt
+++ b/README.txt
@@ -153,6 +153,7 @@ If you find any errors or have suggestions, please open an issue in our [GitHub 
 * Fixed: has-error class on the Gutenberg number field when the field is empty.
 * Fixed: CEP autofill on autocomplete.
 * Fixed: Nonce for the contact number field.
+* Fixed: Address auto-fill on the order edit page.
 
 # 4.14.0 - 27/05/26
 * New: CEP address auto-fill feature.


### PR DESCRIPTION
# Calculadora de frete melhorada para lojas brasileiras

* Contribuidores: LinkNacional, luizbills
* Link para doações: [LinkNacional](https://www.linknacional.com.br/)
* Tags: woocommerce, brasil, calculadora de frete, CEP, carrinho, produto
* Testado até: 6.7
* Requer PHP: 8.0
* Tag estável: 4.15.0
* Licença: GPLv2 ou posterior
* URI da licença: [https://www.gnu.org/licenses/gpl-2.0.html](https://www.gnu.org/licenses/gpl-2.0.html)
* Traduções: Português(Brasil)

## Descrição

Calculadora de frete WooCommerce otimizada para lojas brasileiras com funcionalidades avançadas:

### 🏪 **Na página de Checkout:**
- Campo de número complementar para endereço (`checkbox` ou `text-input`)
- Ocultação inteligente de campos de endereço
- Compatibilidade com modo Legacy e Blocos (Gutenberg)
- **✅ NOVO**: Preenchimento automático de endereço no checkout
- **✅ NOVO**: Destaque visual no campo de CEP do checkout
- **✅ NOVO**: Validação aprimorada do país do telefone — se um dos campos de seleção de país (billing ou shipping) sumir, o valor do campo restante é automaticamente aplicado para ambos, garantindo consistência e evitando erros na validação do telefone

### 🔧 **Personalização:**
Todas as funcionalidades podem ser modificadas ou desativadas usando hooks do WordPress. Consulte nossa seção de [Perguntas Frequentes (FAQ)](https://wordpress.org/support/plugin/woo-better-shipping-calculator-for-brazil/) para mais detalhes.

## 📥 Como instalar?

1. Acesse o painel de administração do WordPress e vá para **Plugins > Adicionar Novo**
2. Pesquise por "Calculadora de frete melhorada para lojas brasileiras"
3. Encontre o plugin, clique em **Instalar Agora** e depois em **Ativar**
4. **Pronto!** O plugin funciona automaticamente, mas você pode acessar **WooCommerce > Configurações > Calculadora de Frete** para personalizar

## 🔄 Fluxo de Desenvolvimento

Este plugin utiliza um fluxo de desenvolvimento automatizado com:
- **Análise de segurança** via CodeQL
- **Verificação de qualidade** WordPress Plugin Check
- **Releases automatizados** com versionamento semântico
- **Testes de compatibilidade** em múltiplas versões do PHP

## 📋 Resumo da Versão 4.15.0

* Novo: Formato para o CNPJ alfanumérico.
* Ajuste: Preenchimento do campo de número na primeira consulta automática.
* Ajuste: Classe has-error no campo de número do Gutenberg quando o campo tá vazio.
* Ajuste: Nonce do campo de número de contato.
* Ajuste: autopreenchimento de endereço na página do pedido.