### PR TITLE
4.17.1 - woo-better-shipping-calculator-for-brazil (Validação do CNPJ)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 env:
   PLUGIN_NAME: woo-better-shipping-calculator-for-brazil
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "4.17.0"
+  DEPLOY_TAG: "4.17.1"
 jobs:
   release-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -11,7 +11,7 @@ on:
 env:
   PLUGIN_NAME: woo-better-shipping-calculator-for-brazil
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "4.17.0-rc.1"
+  DEPLOY_TAG: "4.17.1-rc.1"
 
 jobs:
   release-build:

--- a/.github/workflows/wordpress-release.yml
+++ b/.github/workflows/wordpress-release.yml
@@ -6,7 +6,7 @@ on:
 env:
   PLUGIN_NAME: woo-better-shipping-calculator-for-brazil
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "4.17.0"
+  DEPLOY_TAG: "4.17.1"
 
 jobs:
   deploy-to-wp:

--- a/Admin/partials/WcBetterShippingCalculatorForBrazilCheckoutSettings.php
+++ b/Admin/partials/WcBetterShippingCalculatorForBrazilCheckoutSettings.php
@@ -151,9 +151,9 @@ class WcBetterShippingCalculatorForBrazilCheckoutSettings extends \WC_Settings_P
                         'no'  => __('Desabilitar', 'woo-better-shipping-calculator-for-brazil')
                     ),
                     'custom_attributes' => array(
-                        'data-desc-tip' => __('Após validar o dígito verificador, consulta a Receita Federal (BrasilAPI, com fallback para ReceitaWS) para confirmar que o CNPJ existe.', 'woo-better-shipping-calculator-for-brazil'),
-                        'data-description' => __('Adiciona uma camada extra de validação: além do cálculo do dígito verificador, o plugin consulta a base da Receita Federal para garantir que o CNPJ é real. Aplica-se apenas a CNPJs numéricos.', 'woo-better-shipping-calculator-for-brazil'),
-                        'data-title-description' => __('Confirma na Receita Federal se o CNPJ informado realmente existe.', 'woo-better-shipping-calculator-for-brazil')
+                        'data-desc-tip' => __('Após validar o dígito verificador, consulta a Receita Federal (BrasilAPI, com fallback para ReceitaWS) para confirmar que o CNPJ existe e que a situação cadastral está ativa.', 'woo-better-shipping-calculator-for-brazil'),
+                        'data-description' => __('Adiciona uma camada extra de validação: além do cálculo do dígito verificador, o plugin consulta a base da Receita Federal para garantir que o CNPJ é real e que a situação cadastral está ativa. Aplica-se a CNPJs numéricos e alfanuméricos.', 'woo-better-shipping-calculator-for-brazil'),
+                        'data-title-description' => __('Confirma na Receita Federal se o CNPJ informado realmente existe e está com situação cadastral ativa.', 'woo-better-shipping-calculator-for-brazil')
                     )
                 ),
                 'enable_ie_field' => array(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 4.17.1 - 21/08/26
+* Correção: CNPJ agora é validado pela situação cadastral (ATIVA) na Receita Federal (BrasilAPI e ReceitaWS).
+* Correção: CNPJ alfanumérico (IN RFB 2.229/2024) passou a ser validado pela API (fail-closed) em vez de ser aceito só pelo dígito verificador.
+* Ajuste: Descrição do campo de validação de CNPJ atualizada nas configurações.
+
 # 4.17.0 - 19/08/26
 * Novo: Validação de CNPJ na Receita Federal (BrasilAPI com fallback ReceitaWS).
 * Correção: Campo IE deixou de ser destacado em vermelho sem motivo após erro de validação do CNPJ.

--- a/Includes/WcBetterShippingCalculatorForBrazil.php
+++ b/Includes/WcBetterShippingCalculatorForBrazil.php
@@ -110,7 +110,7 @@ class WcBetterShippingCalculatorForBrazil
         if (defined('WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_VERSION')) {
             $this->version = WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_VERSION;
         } else {
-            $this->version = '4.17.0';
+            $this->version = '4.17.1';
         }
         $this->plugin_name = 'wc-better-shipping-calculator-for-brazil';
 
@@ -275,7 +275,7 @@ class WcBetterShippingCalculatorForBrazil
             $is_new_install = false;
         } else {
             // Prioridade 2: verifica se dispensou notice de alguma das últimas versões
-            $old_versions   = array( '4.16.12', '4.16.11', '4.16.10', '4.16.9', '4.16.8', '4.16.7' ,'4.16.6', '4.16.5', '4.16.4', '4.16.3', '4.16.2', '4.16.1', '4.16.0', '4.15.2' );
+            $old_versions   = array( '4.17.0', '4.16.12', '4.16.11', '4.16.10', '4.16.9', '4.16.8', '4.16.7', '4.16.6', '4.16.5', '4.16.4', '4.16.3', '4.16.2', '4.16.1', '4.16.0' );
             $is_new_install = true;
             foreach ( $old_versions as $old_version ) {
                 if ( get_user_meta( get_current_user_id(), 'woo_better_calc_notice_dismissed_' . $old_version, true ) ) {

--- a/Includes/WcBetterShippingCalculatorForBrazil.php
+++ b/Includes/WcBetterShippingCalculatorForBrazil.php
@@ -2908,12 +2908,13 @@ class WcBetterShippingCalculatorForBrazil
 
         $cnpj = preg_replace('/[^0-9A-Z]/', '', strtoupper($document));
 
-        // CNPJ alfanumérico (IN RFB 2.229/2024) ainda não está disponível nas APIs.
-        // Mantém apenas o resultado do cálculo matemático.
-        if (strlen($cnpj) !== 14 || !ctype_digit($cnpj)) {
+        if (strlen($cnpj) !== 14) {
             return '';
         }
 
+        // CNPJ alfanumérico (IN RFB 2.229/2024) também passa pela API. As APIs
+        // ainda não suportam o novo formato (respondem 400), o que falha fechado
+        // abaixo em vez de aceitar um CNPJ inexistente só pelo dígito verificador.
         $status = $this->cnpj_exists_via_api($cnpj);
 
         if ('found' === $status) {
@@ -2924,15 +2925,19 @@ class WcBetterShippingCalculatorForBrazil
             return __('CNPJ não encontrado na Receita Federal. Verifique o número informado.', 'woo-better-shipping-calculator-for-brazil');
         }
 
+        if ('inactive' === $status) {
+            return __('CNPJ com situação cadastral inativa na Receita Federal.', 'woo-better-shipping-calculator-for-brazil');
+        }
+
         // 'unavailable' — fail-closed.
         return __('Não foi possível validar o CNPJ no momento. Tente novamente em instantes.', 'woo-better-shipping-calculator-for-brazil');
     }
 
     /**
-     * Verifica a existência de um CNPJ numérico via BrasilAPI (fallback ReceitaWS).
+     * Verifica a existência de um CNPJ via BrasilAPI (fallback ReceitaWS).
      *
-     * @param string $cnpj CNPJ limpo (somente dígitos, 14 caracteres).
-     * @return string 'found' | 'not_found' | 'unavailable'
+     * @param string $cnpj CNPJ limpo (sem formatação, 14 caracteres).
+     * @return string 'found' | 'not_found' | 'inactive' | 'unavailable'
      */
     private function cnpj_exists_via_api($cnpj) {
         $cache_key = 'woo_better_shipping_cnpj_' . $cnpj;
@@ -2951,18 +2956,18 @@ class WcBetterShippingCalculatorForBrazil
         // Cacheia apenas resultados definitivos para reduzir chamadas e evitar rate limit.
         if ('found' === $status) {
             set_transient($cache_key, 'found', WEEK_IN_SECONDS);
-        } elseif ('not_found' === $status) {
-            set_transient($cache_key, 'not_found', DAY_IN_SECONDS);
+        } elseif (in_array($status, array('not_found', 'inactive'), true)) {
+            set_transient($cache_key, $status, DAY_IN_SECONDS);
         }
 
         return apply_filters('wc_better_shipping_calculator_cnpj_api_status', $status, $cnpj);
     }
 
     /**
-     * Consulta a BrasilAPI para verificar a existência do CNPJ.
+     * Consulta a BrasilAPI para verificar a existência e a situação cadastral do CNPJ.
      *
-     * @param string $cnpj CNPJ limpo (somente dígitos).
-     * @return string 'found' | 'not_found' | 'unavailable'
+     * @param string $cnpj CNPJ limpo (sem formatação).
+     * @return string 'found' | 'not_found' | 'inactive' | 'unavailable'
      */
     private function cnpj_lookup_brasilapi($cnpj) {
         $url = 'https://brasilapi.com.br/api/cnpj/v1/' . rawurlencode($cnpj);
@@ -2981,22 +2986,38 @@ class WcBetterShippingCalculatorForBrazil
         if (200 === $http_code) {
             $body = json_decode(wp_remote_retrieve_body($response), true);
             $found_cnpj = isset($body['cnpj']) ? preg_replace('/[^0-9]/', '', (string) $body['cnpj']) : '';
-            return ($found_cnpj === $cnpj) ? 'found' : 'unavailable';
+            if ($found_cnpj !== $cnpj) {
+                return 'unavailable';
+            }
+
+            $situacao = '';
+            if (isset($body['descricao_situacao_cadastral'])) {
+                $situacao = strtoupper(trim((string) $body['descricao_situacao_cadastral']));
+            } elseif (isset($body['situacao_cadastral'])) {
+                // 2 = ATIVA na tabela de situação cadastral da Receita Federal.
+                $situacao = (2 === (int) $body['situacao_cadastral']) ? 'ATIVA' : 'INATIVA';
+            }
+
+            if ('' === $situacao) {
+                return 'unavailable';
+            }
+
+            return ('ATIVA' === $situacao) ? 'found' : 'inactive';
         }
 
         if (404 === $http_code) {
             return 'not_found';
         }
 
-        // 429 (rate limit), 5xx e status inesperados.
+        // 400 (CNPJ alfanumérico/novo formato), 429 (rate limit), 5xx e status inesperados.
         return 'unavailable';
     }
 
     /**
-     * Consulta a ReceitaWS (fallback) para verificar a existência do CNPJ.
+     * Consulta a ReceitaWS (fallback) para verificar a existência e a situação cadastral do CNPJ.
      *
-     * @param string $cnpj CNPJ limpo (somente dígitos).
-     * @return string 'found' | 'unavailable'
+     * @param string $cnpj CNPJ limpo (sem formatação).
+     * @return string 'found' | 'inactive' | 'unavailable'
      */
     private function cnpj_lookup_receitaws($cnpj) {
         $url = 'https://receitaws.com.br/v1/cnpj/' . rawurlencode($cnpj);
@@ -3016,7 +3037,16 @@ class WcBetterShippingCalculatorForBrazil
             $body = json_decode(wp_remote_retrieve_body($response), true);
             $is_ok = isset($body['status']) && 'OK' === strtoupper((string) $body['status']);
             $found_cnpj = isset($body['cnpj']) ? preg_replace('/[^0-9]/', '', (string) $body['cnpj']) : '';
-            return ($is_ok && $found_cnpj === $cnpj) ? 'found' : 'unavailable';
+            if (!$is_ok || $found_cnpj !== $cnpj) {
+                return 'unavailable';
+            }
+
+            $situacao = isset($body['situacao']) ? strtoupper(trim((string) $body['situacao'])) : '';
+            if ('' === $situacao) {
+                return 'unavailable';
+            }
+
+            return ('ATIVA' === $situacao) ? 'found' : 'inactive';
         }
 
         // 404 ("not in cache"/"CNPJ inválido"), 429 e 5xx — trata como indisponível,

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 * Tags: woocommerce, brasil, calculadora de frete, CEP, entrega
 * Testado até: 7.1
 * Requer PHP: 8.2
-* Tag estável: 4.17.0
+* Tag estável: 4.17.1
 * Licença: GPLv2 ou posterior
 * URI da licença: [https://www.gnu.org/licenses/gpl-2.0.html](https://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: woocommerce, brasil, calculadora de frete, CEP, entrega
 Requires at least: 5.0
 Tested up to: 7.1
 Requires PHP: 8.2
-Stable tag: 4.17.0
+Stable tag: 4.17.1
 License: GPLv2 or later
 License URI: [https://www.gnu.org/licenses/gpl-2.0.html](https://www.gnu.org/licenses/gpl-2.0.html)
 
@@ -148,6 +148,11 @@ If you find any errors or have suggestions, please open an issue in our [GitHub 
 * [International Telephone Input](https://intl-tel-input.com/) - Phone number field with country code.
 
 == Changelog ==
+
+# 4.17.1 - 2026-08-21
+* Fix: CNPJ now validated for active registration status (situação cadastral ATIVA) against the Federal Revenue (BrasilAPI and ReceitaWS).
+* Fix: Alphanumeric CNPJ (IN RFB 2.229/2024) now goes through the API (fail-closed) instead of being accepted by check digit only.
+* Dev: Updated the CNPJ API validation field description in the settings.
 
 # 4.17.0 - 2026-08-19
 * New: CNPJ validation against the Brazilian Federal Revenue (BrasilAPI with ReceitaWS fallback).

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -50,6 +50,6 @@ class ExampleTest extends WP_UnitTestCase {
      */
     public function test_plugin_constants_are_defined(): void {
         $this->assertTrue( defined( 'WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_VERSION' ) );
-        $this->assertEquals( '4.17.0', WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_VERSION );
+        $this->assertEquals( '4.17.1', WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_VERSION );
     }
 }

--- a/wc-better-shipping-calculator-for-brazil.php
+++ b/wc-better-shipping-calculator-for-brazil.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Calculadora de Frete e Campos Checkout para o Brasil
  * Plugin URI:        https://www.linknacional.com.br/wordpress
  * Description:       Calculadora automática de Frete com CEP para Woocommerce. Sem necessidade de informar o Pais e estado. Compatível com Gutenberg e shortcodes. Ideal para Lojas Brasileiras.
- * Version:           4.17.0
+ * Version:           4.17.1
  * Author:            Link Nacional
  * Author URI:        https://linknacional.com.br/
  * Requires PHP:      8.2
@@ -46,7 +46,7 @@ if (! defined('WPINC')) {
  */
 // Consts
 if (! defined('WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_VERSION')) {
-    define('WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_VERSION', '4.17.0');
+    define('WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_VERSION', '4.17.1');
 }
 
 if (! defined('WC_BETTER_SHIPPING_CALCULATOR_FOR_BRAZIL_MIN_GIVE_VERSION')) {


### PR DESCRIPTION
# Calculadora de frete melhorada para lojas brasileiras

* Contribuidores: LinkNacional, luizbills
* Link para doações: [LinkNacional](https://www.linknacional.com.br/)
* Tags: woocommerce, brasil, calculadora de frete, CEP, carrinho, produto
* Testado até: 7.2
* Requer PHP: 8.2
* Tag estável: 4.17.0
* Licença: GPLv2 ou posterior
* URI da licença: [https://www.gnu.org/licenses/gpl-2.0.html](https://www.gnu.org/licenses/gpl-2.0.html)
* Traduções: Português(Brasil)

## Descrição

Calculadora de frete WooCommerce otimizada para lojas brasileiras com funcionalidades avançadas:

### 🏪 **Na página de Checkout:**
- Campo de número complementar para endereço (`checkbox` ou `text-input`)
- Ocultação inteligente de campos de endereço
- Compatibilidade com modo Legacy e Blocos (Gutenberg)
- **✅ NOVO**: Preenchimento automático de endereço no checkout
- **✅ NOVO**: Destaque visual no campo de CEP do checkout
- **✅ NOVO**: Validação aprimorada do país do telefone — se um dos campos de seleção de país (billing ou shipping) sumir, o valor do campo restante é automaticamente aplicado para ambos, garantindo consistência e evitando erros na validação do telefone

### 🔧 **Personalização:**
Todas as funcionalidades podem ser modificadas ou desativadas usando hooks do WordPress. Consulte nossa seção de [Perguntas Frequentes (FAQ)](https://wordpress.org/support/plugin/woo-better-shipping-calculator-for-brazil/) para mais detalhes.

## 📥 Como instalar?

1. Acesse o painel de administração do WordPress e vá para **Plugins > Adicionar Novo**
2. Pesquise por "Calculadora de frete melhorada para lojas brasileiras"
3. Encontre o plugin, clique em **Instalar Agora** e depois em **Ativar**
4. **Pronto!** O plugin funciona automaticamente, mas você pode acessar **WooCommerce > Configurações > Calculadora de Frete** para personalizar

## 🔄 Fluxo de Desenvolvimento

Este plugin utiliza um fluxo de desenvolvimento automatizado com:
- **Análise de segurança** via CodeQL
- **Verificação de qualidade** WordPress Plugin Check
- **Releases automatizados** com versionamento semântico
- **Testes de compatibilidade** em múltiplas versões do PHP

## 📋 Resumo da Versão 4.17.1

* Correção: CNPJ agora é validado pela situação cadastral (ATIVA) na Receita Federal (BrasilAPI e ReceitaWS).
* Correção: CNPJ alfanumérico (IN RFB 2.229/2024) passou a ser validado pela API (fail-closed) em vez de ser aceito só pelo dígito verificador.
* Ajuste: Descrição do campo de validação de CNPJ atualizada nas configurações.